### PR TITLE
Add fb.check variable which can be disabled to enable fixing exsiting headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@
     <fb.check.skip-findbugs>${fb.check.skip-extended}</fb.check.skip-findbugs>
     <fb.check.skip-pmd>${fb.check.skip-extended}</fb.check.skip-pmd>
     <fb.check.skip-license>${fb.check.skip-extended}</fb.check.skip-license>
+    <fb.check.skip-existing-license>${fb.check.skip-extended}</fb.check.skip-existing-license>
     <fb.check.skip-jacoco>${fb.check.skip-extended}</fb.check.skip-jacoco>
 
     <fb.check.fail-all>true</fb.check.fail-all>
@@ -653,7 +654,7 @@
           <version>2.2</version>
           <configuration>
             <skip>${fb.check.skip-license}</skip>
-            <skipExistingHeaders>true</skipExistingHeaders>
+            <skipExistingHeaders>${fb.check.skip-existing-license}</skipExistingHeaders>
             <failIfMissing>${fb.check.fail-license}</failIfMissing>
             <header>${fb.main.basedir}/src/license/LICENSE-HEADER.txt</header>
             <mapping>


### PR DESCRIPTION
With skipExsitingHeaders set to false, license:format will not fix malformed license, and this functionality is useful to me. This change adds a variable that can be set from command-line to turn this on.
