### PR TITLE
various dependency updates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,23 @@
 
 ## Version 9
 
-* 2013-10-28 - enforce PMD 5.0.5 in the PMD plugin
-* 2013-10-28 - only fail PMD on level 4 and higher
-* 2013-10-28 - enforce findbugs 2.0.2 in the findbugs plugin
+* 2013-11-27 - Remove dep.findbugs-annotations.version, use dep.findbugs.version instead.
+* 2013-11-25 - Remove all PMD rulesets except braces, PMD turns out to
+               be more and more annyoing; rules need to be actively
+               curated.
+               See https://github.com/kitei/kitei-rules/blob/master/src/main/resources/pmd/kitei-standard.xml
+               for an example
+* 2013-11-25 - Upgrade commons-configuration dependency to 1.10 (from 1.9)
+* 2013-11-25 - Upgrade maven-duplicate-finder-plugin plugin to 1.0.5 (from 1.0.4)
+* 2013-11-25 - Upgrade findbugs plugin to 2.5.3 (from 2.5.2)
+* 2013-11-25 - Upgrade deploy plugin to 2.8.1 (from 2.7)
+* 2013-11-25 - Upgrade install plugin to 2.5.1 (from 2.5)
+* 2013-11-25 - Upgrade release plugin to 2.4.2 (from 2.4.1)
+* 2013-11-25 - Upgrade license plugin to 2.5 (from 2.2)
+* 2013-11-25 - Enforce findbugs 2.0.2 in the findbugs plugin
+* 2013-10-31 - Fix surefire argline to work with code coverage
+* 2013-10-28 - Enforce PMD 5.0.5 in the PMD plugin
+* 2013-10-28 - Only fail PMD on level 4 and higher
 
 ## Version 8
 

--- a/pom.xml
+++ b/pom.xml
@@ -152,10 +152,14 @@
     <dep.plugin.surefire.version>2.16</dep.plugin.surefire.version>
     <dep.plugin.site.version>3.3</dep.plugin.site.version>
     <dep.plugin.pmd.version>3.0.1</dep.plugin.pmd.version>
-    <dep.plugin.findbugs.version>2.5.2</dep.plugin.findbugs.version>
+    <dep.plugin.findbugs.version>2.5.3</dep.plugin.findbugs.version>
     <dep.plugin.jacoco.version>0.6.3.201306030806</dep.plugin.jacoco.version>
     <dep.plugin.scm.version>1.8.1</dep.plugin.scm.version>
     <dep.plugin.javadoc.version>2.9.1</dep.plugin.javadoc.version>
+
+    <!-- used by plugins -->
+    <dep.pmd.version>5.0.5</dep.pmd.version>
+    <dep.findbugs.version>2.0.2</dep.findbugs.version>
 
     <!-- Dependency versions that should be the same everywhere. -->
     <dep.guice.version>3.0</dep.guice.version>
@@ -169,12 +173,11 @@
     <dep.log4j.version>1.2.17</dep.log4j.version>
     <dep.commons-lang3.version>3.1</dep.commons-lang3.version>
     <dep.commons-lang.version>2.6</dep.commons-lang.version>
-    <dep.commons-configuration.version>1.9</dep.commons-configuration.version>
+    <dep.commons-configuration.version>1.10</dep.commons-configuration.version>
     <dep.commons-codec.version>1.8</dep.commons-codec.version>
     <dep.commons-collections.version>3.2.1</dep.commons-collections.version>
     <dep.commons-io.version>2.4</dep.commons-io.version>
     <dep.commons-beanutils.version>1.8.3</dep.commons-beanutils.version>
-    <dep.findbugs-annotations.version>2.0.2</dep.findbugs-annotations.version>
     <dep.junit.version>4.11</dep.junit.version>
     <dep.testng.version>6.8.7</dep.testng.version>
     <dep.easymock.version>3.2</dep.easymock.version>
@@ -261,7 +264,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>2.7</version>
+          <version>2.8.1</version>
         </plugin>
 
         <plugin>
@@ -273,7 +276,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
-          <version>2.5</version>
+          <version>2.5.1</version>
         </plugin>
 
         <plugin>
@@ -420,7 +423,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
-          <version>2.4.1</version>
+          <version>2.4.2</version>
           <configuration>
             <releaseProfiles>oss-release</releaseProfiles>
             <autoVersionSubmodules>true</autoVersionSubmodules>
@@ -504,7 +507,7 @@
         <plugin>
           <groupId>com.ning.maven.plugins</groupId>
           <artifactId>maven-duplicate-finder-plugin</artifactId>
-          <version>1.0.4</version>
+          <version>1.0.5</version>
           <executions>
             <execution>
               <id>default</id>
@@ -602,7 +605,7 @@
             <dependency>
               <groupId>com.google.code.findbugs</groupId>
               <artifactId>findbugs</artifactId>
-              <version>2.0.2</version>
+              <version>${dep.findbugs.version}</version>
             </dependency>
           </dependencies>
           <configuration>
@@ -629,7 +632,7 @@
             <dependency>
               <groupId>net.sourceforge.pmd</groupId>
               <artifactId>pmd</artifactId>
-              <version>5.0.5</version>
+              <version>${dep.pmd.version}</version>
             </dependency>
           </dependencies>
           <configuration>
@@ -647,9 +650,10 @@
               <excludeRoot>target/generated-sources/stubs</excludeRoot>
             </excludeRoots>
             <rulesets>
-              <ruleset>/rulesets/java/basic.xml</ruleset>
-              <ruleset>/rulesets/java/clone.xml</ruleset>
-              <ruleset>/rulesets/java/finalizers.xml</ruleset>
+              <!-- it would be great to use no rules here but then PMD crashes -->
+              <!-- https://sourceforge.net/p/pmd/bugs/1155/ -->
+              <!-- so use the least offensive one -->
+              <ruleset>/rulesets/java/braces.xml</ruleset>
             </rulesets>
           </configuration>
           <executions>
@@ -666,7 +670,7 @@
         <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>
-          <version>2.2</version>
+          <version>2.5</version>
           <configuration>
             <skip>${fb.check.skip-license}</skip>
             <skipExistingHeaders>true</skipExistingHeaders>
@@ -1124,7 +1128,7 @@
       <dependency>
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>annotations</artifactId>
-        <version>${dep.findbugs-annotations.version}</version>
+        <version>${dep.findbugs.version}</version>
       </dependency>
 
       <!-- Testing -->


### PR DESCRIPTION
Please review; this will be applied once findbugs 2.0.3 actually hits maven central (it hasn't yet).
