### PR TITLE
Adjust install and deploy ordering for multi-module projects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,6 +266,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
           <version>2.8.1</version>
+          <configuration>
+            <!-- Don't deploy any part of a multimodule project unless tests
+                 and checks for all previous phases have succeeded -->
+            <deployAtEnd>true</deployAtEnd>
+          </configuration>
         </plugin>
 
         <plugin>
@@ -278,6 +283,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
           <version>2.5.1</version>
+          <configuration>
+            <!-- Don't install any part of a multimodule project unless tests
+                 and checks for all previous phases have succeeded -->
+            <installAtEnd>true</installAtEnd>
+          </configuration>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
By default, multi-module projects will install/deploy as each module
builds and passes tests. It seems much safer to configure the respective
plugins to only install/deploy after all modules have built and passed
tests and checks.
